### PR TITLE
Current check for local plugins uses the current working directory wh…

### DIFF
--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -18,6 +18,11 @@ function load_plugins(config, plugin_configs, params, sanity_check) {
     // try local plugins first
     plugin = try_load(Path.resolve('./lib/plugins', p))
 
+    // second check for local plugins
+    if (plugin === null) {
+      plugin = try_load(Path.resolve(__dirname + '/plugins', p))
+    }
+
     // npm package
     if (plugin === null && p.match(/^[^\.\/]/)) {
       plugin = try_load('sinopia-' + p)


### PR DESCRIPTION
…ich, in some cases, results in a plugin not found error.

Added a second check for local plugins using __dirname to find plugins relative to the executing script.
